### PR TITLE
add example_inputs argument

### DIFF
--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
@@ -32,7 +32,7 @@ class Model(BenchmarkModel):
     def prep_qat_train(self):
         qconfig_dict = {"": torch.quantization.get_default_qat_qconfig('fbgemm')}
         self.model.train()
-        self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict)
+        self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict, self.example_inputs)
 
     def train(self, niter=3):
         optimizer = optim.Adam(self.model.parameters())

--- a/torchbenchmark/models/resnet50_quantized_qat/__init__.py
+++ b/torchbenchmark/models/resnet50_quantized_qat/__init__.py
@@ -32,7 +32,7 @@ class Model(BenchmarkModel):
     def prep_qat_train(self):
         qconfig_dict = {"": torch.quantization.get_default_qat_qconfig('fbgemm')}
         self.model.train()
-        self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict)
+        self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict, self.example_inputs)
 
     def get_module(self):
         return self.model, self.example_inputs


### PR DESCRIPTION
Needed to add these two `self.example_inputs` argument to run the benchmark in torchdynamo.
These two arguments are also in the pytorch/benchmark repo: e.g. https://github.com/pytorch/benchmark/blob/main/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py#L35 